### PR TITLE
feature/000 adding .env minimum config to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ At a minimum, you'll need Node.js installed, a LESS compiler, and access to a Mo
 `$ sh bootstrap.sh`
 
 This application uses Discord for authentication, and you'll need to [create an application](https://discordapp.com/developers/applications/me) for testing purposes. Once it's set up, add your Client ID/Secret to the .env file.
+
+# Env file minimum setup
+
+This example uses localhost default configuration for your `.env` file
+```
+DISCORD_CLIENT_ID=<your discord app id>
+DISCORD_CLIENT_SECRET=<your discord client secret>
+DISCORD_CALLBACK_URL=http://127.0.0.1:3000/users/auth/discord/callback
+SESSION_SECRET=dev-secret
+DB_HOST=localhost
+DB_PORT=27017
+DB_NAME=test
+NODE_APP_INSTANCE=1
+```
+


### PR DESCRIPTION

## Description
This PR provides the minimum configuration need on the `.env` file to run it locally

## Motivation and Context
This will make life easy for people that want to contribute but are not familiarized with the code. 

## How Has This Been Tested?
1. Setup the information correctly
2. run `npm start` or `yarn start`
3. Server should start on http://localhost:3000
